### PR TITLE
add(computePrizeDistributionFromTicketAverageTotalSupplies): compute prize distribution per token average totalSupply

### DIFF
--- a/src/computeCardinality.ts
+++ b/src/computeCardinality.ts
@@ -1,23 +1,23 @@
 import { BigNumber, utils } from "ethers";
 
 export function computeCardinality(
-  bitRangeSize: number,
+  bitRangeSize: BigNumber,
   totalSupply: BigNumber,
-  totalSupplyDecimals: number
+  totalSupplyDecimals: BigNumber
 ): number {
   let numberOfPicks;
-  let matchCardinality = 2;
-  const range = 2 ** bitRangeSize;
+  let matchCardinality = BigNumber.from(2);
+  const range = BigNumber.from(2).pow(bitRangeSize);
 
   do {
     numberOfPicks = utils.parseUnits(
-      `${range ** ++matchCardinality}`,
+      `${range.pow(matchCardinality.add(1))}`,
       totalSupplyDecimals
     );
   } while (numberOfPicks.lt(totalSupply));
 
-  matchCardinality--;
-  return matchCardinality;
+  matchCardinality.sub(1);
+  return matchCardinality.toNumber();
 }
 
 export default computeCardinality;

--- a/src/computeCardinality.ts
+++ b/src/computeCardinality.ts
@@ -1,22 +1,32 @@
-import { BigNumber, utils } from "ethers";
+import { BigNumber } from '@ethersproject/bignumber'
+import { utils } from "ethers";
+const debug = require('debug')('pt-v4-js')
 
 export function computeCardinality(
   bitRangeSize: BigNumber,
   totalSupply: BigNumber,
   totalSupplyDecimals: BigNumber
 ): number {
+  debug("computeCardinality:ENTER")
   let numberOfPicks;
   let matchCardinality = BigNumber.from(2);
   const range = BigNumber.from(2).pow(bitRangeSize);
-
+  debug("computeCardinality:matchCardinality: ", matchCardinality.toString());
+  debug("computeCardinality:range: ", range.toString());
+  debug("computeCardinality:totalSupply: ", totalSupply.toString());
+  debug("computeCardinality:totalSupplyDecimals: ", totalSupplyDecimals.toString());
   do {
+
     numberOfPicks = utils.parseUnits(
-      `${range.pow(matchCardinality.add(1))}`,
+      `${range.pow(matchCardinality)}`,
       totalSupplyDecimals
     );
+    matchCardinality = matchCardinality.add(1);
+    debug("computeCardinality:numberOfPicks:loop: ", numberOfPicks.toString());
   } while (numberOfPicks.lt(totalSupply));
-
-  matchCardinality.sub(1);
+  debug("computeCardinality:numberOfPicks: ", numberOfPicks.toString());
+  matchCardinality = matchCardinality.sub(1);
+  debug("computeCardinality:matchCardinality: ", matchCardinality.toString());
   return matchCardinality.toNumber();
 }
 

--- a/src/computePrizeDistributionFromTicketAverageTotalSupplies.ts
+++ b/src/computePrizeDistributionFromTicketAverageTotalSupplies.ts
@@ -1,0 +1,90 @@
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { Draw, PrizeDistribution, PrizeTier } from "./types";
+import {
+  calculatePicksFromAverageTotalSuppliesBetween,
+  computeCardinality,
+} from "./index";
+import { sumBigNumbers } from "./utils";
+const debug = require("debug")("v4-js-core");
+
+function createBigNumber(value: BigNumberish) {
+  return BigNumber.from(value);
+}
+
+export async function computePrizeDistributionFromTicketAverageTotalSupplies(
+  draw: Draw,
+  prizeTier?: PrizeTier,
+  ticketPrimaryAverageTotalSupply?: BigNumberish,
+  ticketSecondaryListAverageTotalSupply?: Array<BigNumberish>,
+  decimals: BigNumberish = 18
+): Promise<PrizeDistribution | undefined> {
+  if (
+    !draw ||
+    !prizeTier ||
+    !ticketPrimaryAverageTotalSupply ||
+    !ticketSecondaryListAverageTotalSupply
+  )
+    return undefined;
+
+  const { beaconPeriodSeconds } = draw;
+  const {
+    expiryDuration,
+    bitRangeSize,
+    maxPicksPerUser,
+    endTimestampOffset,
+    tiers,
+    prize,
+  } = prizeTier;
+
+  const ticketPrimaryAverageTotalSupplyBigNumber = createBigNumber(
+    ticketPrimaryAverageTotalSupply
+  );
+  const ticketSecondaryListAverageTotalSupplyBigNumber = ticketSecondaryListAverageTotalSupply.map(
+    createBigNumber
+  );
+
+  // Sums the ALL ticket average total supplies.
+  const totalAverageSupplies = sumBigNumbers([
+    ticketPrimaryAverageTotalSupplyBigNumber,
+    ...ticketSecondaryListAverageTotalSupplyBigNumber,
+  ]);
+
+  // Sums ALL SECONDARY ticket average total supplies.
+  const secondaryTotalAverageSupplies = sumBigNumbers(
+    ticketSecondaryListAverageTotalSupplyBigNumber
+  );
+
+  const matchCardinality = computeCardinality(
+    BigNumber.from(bitRangeSize),
+    totalAverageSupplies,
+    BigNumber.from(decimals)
+  );
+
+  let numberOfPicks;
+  const totalPicks = BigNumber.from(BigNumber.from(2).pow(bitRangeSize)).pow(
+    matchCardinality
+  );
+
+  if (totalAverageSupplies.gt("0")) {
+    numberOfPicks = calculatePicksFromAverageTotalSuppliesBetween(
+      totalPicks.toNumber(),
+      BigNumber.from(ticketPrimaryAverageTotalSupply),
+      secondaryTotalAverageSupplies
+    );
+  }
+
+  const prizeDistribution: PrizeDistribution = {
+    bitRangeSize: bitRangeSize,
+    matchCardinality,
+    tiers: tiers,
+    maxPicksPerUser: maxPicksPerUser,
+    expiryDuration,
+    numberOfPicks: BigNumber.from(numberOfPicks),
+    startTimestampOffset: beaconPeriodSeconds,
+    prize: prize,
+    endTimestampOffset,
+  };
+  debug(`computePrizeDistribution:prizeDistribution: `, prizeDistribution);
+
+  return prizeDistribution;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from "./calculatePicksFromAverageTotalSuppliesBetween";
 export * from "./computeCardinality";
 export * from "./computePicks";
 export * from "./computeDrawResults";
+export * from "./computePrizeDistributionFromTicketAverageTotalSupplies";
 export * from "./generatePicks";
 export * from "./prepareClaims";

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,10 @@ export interface PrizeTier {
   bitRangeSize: number;
   drawId: number;
   maxPicksPerUser: number;
-  prize: number;
-  tiers: number;
-  validityDuration: number;
+  expiryDuration: number;
+  endTimestampOffset: number;
+  prize: BigNumber;
+  tiers: Array<number>;
 }
 
 export interface Pick {

--- a/test/computeCardinality.test.ts
+++ b/test/computeCardinality.test.ts
@@ -3,9 +3,9 @@ import { computeCardinality } from "../src";
 
 describe("computeCardinality", () => {
   it("should compute cardinality for a small bitrange and total supply", () => {
-    const bitRangeSize = 2;
+    const bitRangeSize = BigNumber.from(2);
     const totalSupply = BigNumber.from("450");
-    const totalSupplyDecimals = 18;
+    const totalSupplyDecimals = BigNumber.from(18)
     const cardinality = computeCardinality(
       bitRangeSize,
       totalSupply,

--- a/test/computePrizeDistributionFromTicketAverageTotalSupplies.test.ts
+++ b/test/computePrizeDistributionFromTicketAverageTotalSupplies.test.ts
@@ -1,0 +1,50 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { computePrizeDistributionFromTicketAverageTotalSupplies } from "../src";
+import { PrizeTier } from "../src/types";
+const debug = require("debug")("v4-js-core:test");
+
+describe("computePrizeDistributionFromTicketAverageTotalSupplies", () => {
+  it("should succeed to calculate a valid PrizeDistribution", async () => {
+    const draw = {
+      winningRandomNumber: BigNumber.from(
+        "21288413488180966377126236036201345909019919575750940621513526137694302720820"
+      ),
+      drawId: 1,
+      timestamp: 1634410924,
+      beaconPeriodStartedAt: 1634324400,
+      beaconPeriodSeconds: 86400,
+    };
+
+    const prizeTier: PrizeTier = {
+      bitRangeSize: 2,
+      endTimestampOffset: 0,
+      maxPicksPerUser: 2,
+      expiryDuration: 86400,
+      drawId: 1,
+      prize: BigNumber.from('100000000000000'),
+      tiers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,]
+    }
+
+    const expectation = {
+      bitRangeSize: 2,
+      matchCardinality: 2,
+      tiers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      maxPicksPerUser: 2,
+      expiryDuration: 86400,
+      numberOfPicks: BigNumber.from({ _hex: "0x03", _isBigNumber: true }),
+      startTimestampOffset: 86400,
+      prize: BigNumber.from({ _hex: "0x5af3107a4000", _isBigNumber: true }),
+      endTimestampOffset: 0,
+    };
+
+    const results = await computePrizeDistributionFromTicketAverageTotalSupplies(
+      draw,
+      prizeTier,
+      BigNumber.from(100000),
+      [BigNumber.from(200000), BigNumber.from(200000)]
+    );
+
+    debug("computePrizeDistributionFromTicketAverageTotalSupplies", results);
+    expect(results).toEqual(expectation);
+  });
+});


### PR DESCRIPTION
Creates the `computePrizeDistributionFromTicketAverageTotalSupplies` function which replaces the recently removed `computePrizeDistributionFrom` function that required reads to external contracts.

Still requires tests for completition.
